### PR TITLE
Allow passing a custom session object to `get_artifact_info_as_json`

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -4,7 +4,7 @@ import json
 import tarfile
 import warnings
 from pathlib import Path
-from typing import Any, Generator, Tuple
+from typing import Any, Generator, Optional, Tuple
 
 import requests
 from ruamel import yaml
@@ -21,7 +21,7 @@ def get_artifact_info_as_json(
     artifact: str,
     backend: str = "oci",
     skip_files_suffixes: Tuple[str, ...] = (".pyc", ".txt"),
-    session: requests.Session | None = None,
+    session: Optional[requests.Session] = None,
 ) -> ArtifactData | None:
     """Get a blob of artifact data from the conda info directory.
 

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -92,7 +92,7 @@ def get_artifact_info_as_json(
         from conda_forge_metadata.streaming import get_streamed_artifact_data
 
         return info_json_from_tar_generator(
-            get_streamed_artifact_data(channel, subdir, artifact, session),
+            get_streamed_artifact_data(channel, subdir, artifact, session=session),
             skip_files_suffixes=skip_files_suffixes,
         )
     else:

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -6,6 +6,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Generator, Tuple
 
+import requests
 from ruamel import yaml
 
 from conda_forge_metadata.libcfgraph import get_libcfgraph_artifact_data
@@ -20,6 +21,7 @@ def get_artifact_info_as_json(
     artifact: str,
     backend: str = "oci",
     skip_files_suffixes: Tuple[str, ...] = (".pyc", ".txt"),
+    session: requests.Session | None = None,
 ) -> ArtifactData | None:
     """Get a blob of artifact data from the conda info directory.
 
@@ -38,6 +40,11 @@ def get_artifact_info_as_json(
     skip_files_suffixes : Tuple[str, ...], optional
         A tuple of suffixes to skip when reporting the files in the
         artifact. The default is (".pyc", ".txt").
+    session : requests.Session, optional
+        A session object to use for HTTP requests. If not provided, a default
+        session object is used.
+        Note: Currently, this is only used for the "streamed" backend. If the
+        backend is "oci", this parameter is ignored.
 
     Returns
     -------
@@ -85,7 +92,7 @@ def get_artifact_info_as_json(
         from conda_forge_metadata.streaming import get_streamed_artifact_data
 
         return info_json_from_tar_generator(
-            get_streamed_artifact_data(channel, subdir, artifact),
+            get_streamed_artifact_data(channel, subdir, artifact, session),
             skip_files_suffixes=skip_files_suffixes,
         )
     else:

--- a/conda_forge_metadata/streaming.py
+++ b/conda_forge_metadata/streaming.py
@@ -4,11 +4,14 @@ Use conda-package-streaming to fetch package metadata
 
 from contextlib import closing
 
+import requests
 from conda_package_streaming.package_streaming import stream_conda_component
 from conda_package_streaming.url import conda_reader_for_url
 
 
-def get_streamed_artifact_data(channel: str, subdir: str, artifact: str):
+def get_streamed_artifact_data(
+    channel: str, subdir: str, artifact: str, session: requests.Session | None = None
+):
     if not channel.startswith("http"):
         if channel in ("pkgs/main", "pkgs/r", "pkgs/msys2"):
             channel = f"https://repo.anaconda.com/{channel}"
@@ -17,7 +20,9 @@ def get_streamed_artifact_data(channel: str, subdir: str, artifact: str):
 
     # .conda artifacts can be streamed directly from an anaconda.org channel
     url = f"{channel}/{subdir}/{artifact}"
-    filename, conda = conda_reader_for_url(url)
+
+    session_arg = [session] if session is not None else []
+    filename, conda = conda_reader_for_url(url, *session_arg)
 
     with closing(conda):
         yield from stream_conda_component(filename, conda, component="info")

--- a/conda_forge_metadata/streaming.py
+++ b/conda_forge_metadata/streaming.py
@@ -3,6 +3,7 @@ Use conda-package-streaming to fetch package metadata
 """
 
 from contextlib import closing
+from typing import Optional
 
 import requests
 from conda_package_streaming.package_streaming import stream_conda_component
@@ -10,7 +11,7 @@ from conda_package_streaming.url import conda_reader_for_url
 
 
 def get_streamed_artifact_data(
-    channel: str, subdir: str, artifact: str, session: requests.Session | None = None
+    channel: str, subdir: str, artifact: str, session: Optional[requests.Session] = None
 ):
     if not channel.startswith("http"):
         if channel in ("pkgs/main", "pkgs/r", "pkgs/msys2"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
-conda-oci-mirror
 deprecated
+git+https://github.com/channel-mirrors/conda-oci-mirror.git@v0.1.0
 requests
 ruamel.yaml
 typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4
+conda-oci-mirror
 deprecated
-git+https://github.com/channel-mirrors/conda-oci-mirror.git@v0.1.0
 requests
 ruamel.yaml
 typing-extensions

--- a/tests/test_info_json.py
+++ b/tests/test_info_json.py
@@ -1,4 +1,7 @@
+from unittest.mock import MagicMock
+
 import pytest
+import requests
 
 from conda_forge_metadata.artifact_info import info_json
 
@@ -86,6 +89,21 @@ def test_info_json_conda_unlucky_test_file(backend: str):
     assert info["index"]["version"] == "1.9.1"
     assert info["index"]["build"] == "pyhd8ed1ab_0"
     assert info["index"]["subdir"] == "noarch"
+
+
+def test_info_json_custom_session_object():
+    session = MagicMock()
+    session.get.side_effect = requests.get
+
+    info_json.get_artifact_info_as_json(
+        "conda-forge",
+        "noarch",
+        "nodeenv-1.9.1-pyhd8ed1ab_0.conda",
+        backend="streamed",
+        session=session,
+    )
+
+    session.get.assert_called()
 
 
 @pytest.mark.parametrize("backend", info_json.VALID_BACKENDS)


### PR DESCRIPTION
Under certain circumstances (HTTP proxy, private conda registry), it might be desirable to pass a custom session object to `get_artifact_info_as_json`. This PR implements the necessary changes for that.