### PR TITLE
Add rattler-build support for info_json_from_tar_generator

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -58,13 +58,17 @@ def get_artifact_info_as_json(
             "about": the info/about.json file contents
             "rendered_recipe": the fully rendered recipe at
                 either info/recipe/meta.yaml or info/meta.yaml
-                as a dict
+                as a dict.
+                For rattler-build recipes, we use rendered_recipe.yaml.
             "raw_recipe": the template recipe as a string from
                 info/recipe/meta.yaml.template - could be
-                the rendered recipe as a string if no template was found
+                the rendered recipe as a string if no template was found.
+                For rattler-build recipes, we use recipe.yaml.
             "conda_build_config": the conda_build_config.yaml used for building
                 the recipe at info/recipe/conda_build_config.yaml
-            "files": a list of files in the recipe from info/files with
+                For rattler-build recipes, we use variant_config.yaml instead.
+            "files": a list of files in the recipe from info/paths.json
+                (or fallback to info/files if info/paths.json doesn't exist) with
                 elements ending in .pyc or .txt filtered out.
     """
     if backend == "libcfgraph":
@@ -156,6 +160,11 @@ def info_json_from_tar_generator(
                     f for f in files if not f.lower().endswith(skip_files_suffixes)
                 ]
             data["files"] = files
+        elif path.name == "files":
+            # prefer files from paths.json if available
+            if data["files"]:
+                continue
+            files = _extract_read(tar, member, default="").splitlines()
         elif path.name == "meta.yaml.template":
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif path.name == "meta.yaml":

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -138,8 +138,15 @@ def info_json_from_tar_generator(
             data["conda_build_config"] = YAML.load(
                 _extract_read(tar, member, default="{}")
             )
-        elif path.name == "files":
-            files = _extract_read(tar, member, default="").splitlines()
+        elif path.name == "paths.json":
+            paths = json.loads(_extract_read(tar, member, default="{}"))
+            paths_version = paths.get("paths_version", 1)
+            if paths_version != 1:
+                warnings.warn(
+                    f"Unrecognized paths_version {paths_version} in paths.json",
+                    RuntimeWarning,
+                )
+            files = [p.get("_path", "") for p in paths.get("paths", [])]
             if skip_files_suffixes:
                 files = [
                     f for f in files if not f.lower().endswith(skip_files_suffixes)

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -135,6 +135,12 @@ def info_json_from_tar_generator(
         elif path.name == "about.json":
             data["about"] = json.loads(_extract_read(tar, member, default="{}"))
         elif path.name == "conda_build_config.yaml":
+            assert data["conda_build_config"] == {}
+            data["conda_build_config"] = YAML.load(
+                _extract_read(tar, member, default="{}")
+            )
+        elif path.name == "variant_config.yaml":
+            assert data["conda_build_config"] == {}
             data["conda_build_config"] = YAML.load(
                 _extract_read(tar, member, default="{}")
             )
@@ -153,13 +159,21 @@ def info_json_from_tar_generator(
                 ]
             data["files"] = files
         elif path.name == "meta.yaml.template":
+            assert data["raw_recipe"] == ""
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif path.name == "meta.yaml":
             x = _extract_read(tar, member, default="{}")
             if ("{{" in x or "{%" in x) and not data["raw_recipe"]:
                 data["raw_recipe"] = x
             else:
+                assert data["rendered_recipe"] == {}
                 data["rendered_recipe"] = YAML.load(x)
+        elif path.name == "recipe.yaml":
+            assert data["raw_recipe"] == ""
+            data["raw_recipe"] = _extract_read(tar, member, default="")
+        elif path.name == "rendered_recipe.yaml":
+            assert data["rendered_recipe"] == {}
+            data["rendered_recipe"] = YAML.load(_extract_read(tar, member, default=""))
     if data["name"]:
         return data  # type: ignore
 

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -135,12 +135,10 @@ def info_json_from_tar_generator(
         elif path.name == "about.json":
             data["about"] = json.loads(_extract_read(tar, member, default="{}"))
         elif path.name == "conda_build_config.yaml":
-            assert data["conda_build_config"] == {}
             data["conda_build_config"] = YAML.load(
                 _extract_read(tar, member, default="{}")
             )
         elif path.name == "variant_config.yaml":
-            assert data["conda_build_config"] == {}
             data["conda_build_config"] = YAML.load(
                 _extract_read(tar, member, default="{}")
             )
@@ -159,20 +157,16 @@ def info_json_from_tar_generator(
                 ]
             data["files"] = files
         elif path.name == "meta.yaml.template":
-            assert data["raw_recipe"] == ""
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif path.name == "meta.yaml":
             x = _extract_read(tar, member, default="{}")
             if ("{{" in x or "{%" in x) and not data["raw_recipe"]:
                 data["raw_recipe"] = x
             else:
-                assert data["rendered_recipe"] == {}
                 data["rendered_recipe"] = YAML.load(x)
         elif path.name == "recipe.yaml":
-            assert data["raw_recipe"] == ""
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif path.name == "rendered_recipe.yaml":
-            assert data["rendered_recipe"] == {}
             data["rendered_recipe"] = YAML.load(_extract_read(tar, member, default=""))
     if data["name"]:
         return data  # type: ignore

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -165,6 +165,11 @@ def info_json_from_tar_generator(
             if data["files"]:
                 continue
             files = _extract_read(tar, member, default="").splitlines()
+            if skip_files_suffixes:
+                files = [
+                    f for f in files if not f.lower().endswith(skip_files_suffixes)
+                ]
+            data["files"] = files
         elif path.name == "meta.yaml.template":
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif path.name == "meta.yaml":

--- a/tests/test_info_json.py
+++ b/tests/test_info_json.py
@@ -68,6 +68,35 @@ def test_info_json_conda(backend: str):
 
 
 @pytest.mark.parametrize("backend", info_json.VALID_BACKENDS)
+def test_info_json_rattler_build(backend: str):
+    info = info_json.get_artifact_info_as_json(
+        "conda-forge",
+        "linux-64",
+        "jolt-physics-5.1.0-hff21bea_0.conda",
+        backend=backend,
+    )
+    assert info is not None
+    assert info["metadata_version"] == 1
+    assert info["name"] == "jolt-physics"
+    assert info["version"] == "5.1.0"
+    assert info["index"]["name"] == "jolt-physics"
+    assert info["index"]["version"] == "5.1.0"
+    assert info["index"]["build"] == "hff21bea_0"
+    assert info["index"]["subdir"] == "linux-64"
+    assert "libstdcxx >=13" in info["index"]["depends"]
+    assert "conda_version" not in info["about"]
+    assert info["rendered_recipe"]["recipe"]["package"]["name"] == "jolt-physics"
+    assert (
+        info["rendered_recipe"]["recipe"]["source"][0]["sha256"]
+        == "10fcc863ae2b9d48c2f22d8b0204034820e57a55f858b7c388ac9579d8cf4095"
+    )
+    assert info["raw_recipe"] is not None
+    assert info["raw_recipe"].startswith("context:\n")
+    assert info["conda_build_config"]["c_stdlib"] == "sysroot"
+    assert "include/Jolt/AABBTree/AABBTreeBuilder.h" in info["files"]
+
+
+@pytest.mark.parametrize("backend", info_json.VALID_BACKENDS)
 def test_info_json_conda_unlucky_test_file(backend: str):
     """
     See https://github.com/conda-forge/conda-forge-metadata/pull/36


### PR DESCRIPTION
The `paths.json` file is available in conda packages for quite some time and contains a superset of information of `files` and `has_prefix`. It is supported by both conda-build and rattler-build while rattler-build doesn't generate a `files` object.

This PR also adds support for rattler-build's rendered recipe, raw recipe as well as variant config