### PR TITLE
Parse `info/paths.json` as alternative to `info/files`

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -173,7 +173,10 @@ def info_json_from_tar_generator(
         elif path.name == "paths.json" and not data.get("files"):
             paths = json.loads(_extract_read(tar, member, default="[]"))
             if (paths_version := paths.get("paths_version", 1)) > 1:
-                log.warning("paths.json version is too recent: %s", paths_version)
+                warnings.warn(
+                    "paths.json version is too recent: %s" % paths_version,
+                    RuntimeWarning,
+                )
                 continue
             files = [p["_path"] for p in paths.get("paths", ())]
             if skip_files_suffixes:

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -170,6 +170,17 @@ def info_json_from_tar_generator(
                     f for f in files if not f.lower().endswith(skip_files_suffixes)
                 ]
             data["files"] = files
+        elif path.name == "paths.json" and not data.get("files"):
+            paths = json.loads(_extract_read(tar, member, default="[]"))
+            if (paths_version := paths.get("paths_version", 1)) > 1:
+                log.warning("paths.json version is too recent: %s", paths_version)
+                continue
+            files = [p["_path"] for p in paths.get("paths", ())]
+            if skip_files_suffixes:
+                files = [
+                    f for f in files if not f.lower().endswith(skip_files_suffixes)
+                ]
+            data["files"] = files
         elif path.name == "meta.yaml.template":
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif path.name == "meta.yaml":

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -160,7 +160,7 @@ def info_json_from_tar_generator(
                     f for f in files if not f.lower().endswith(skip_files_suffixes)
                 ]
             data["files"] = files
-        elif path.name == "files":
+        elif path.name == "files" and not data.get("files"):
             # prefer files from paths.json if available
             if data["files"]:
                 continue


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

rattler-build artifacts do not include `info/files`, but do include `paths.json`, so parse that as a fallback. [example](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Flibamd-3.3.3-ss783_h889e182.conda).

cc @h-vetinari 