### PR TITLE
Split PyPI upload workflow in two jobs

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,45 +10,50 @@ on:
       - published
 
 jobs:
-  packages:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.x"
 
-      - name: Get tags
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-        shell: bash
-
       - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip wheel setuptools setuptools_scm build twine
+        run: python -m pip install --upgrade pip wheel setuptools setuptools_scm build twine
 
-        shell: bash
-
-      - name: Build binary wheel
+      - name: Build wheels
         run: python -m build --sdist --wheel . --outdir dist
 
-      - name: CheckFiles
+      - name: Check wheels
+        working-directory: dist
         run: |
-          ls dist
-        shell: bash
-
-      - name: Test wheels
-        run: |
-          pushd dist
-          python -m pip install conda_forge_metadata*.whl
+          ls -alh
+          python -m pip install *.whl
           python -m twine check *
-          popd
-        shell: bash
 
-      - name: Publish a Python distribution to PyPI
-        if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
+      - name: Upload release distributions
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          name: release-dists
+          path: dist/
+
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs: [build]
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
Also remove the token-based uploads in favor of OIDC based ones. Need to configure the repo as per: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-pypi